### PR TITLE
[AS-3971] Support new version of 'Woocommerce shipment tracking'

### DIFF
--- a/aftership.php
+++ b/aftership.php
@@ -3,7 +3,7 @@
 	Plugin Name: AfterShip - WooCommerce Tracking
 	Plugin URI: http://aftership.com/
 	Description: Add tracking number and carrier name to WooCommerce, display tracking info at order history page, auto import tracking numbers to AfterShip.
-	Version: 1.6.4
+	Version: 1.6.5
 	Author: AfterShip
 	Author URI: http://aftership.com
 

--- a/class-aftership-dependencies.php
+++ b/class-aftership-dependencies.php
@@ -13,7 +13,17 @@ class AfterShip_Dependencies {
 
 	public static function plugin_active_check($plugin){
 		if ( ! self::$active_plugins ) self::init();
-		return in_array( $plugin, self::$active_plugins ) || array_key_exists( $plugin, self::$active_plugins );
+		if (is_array($plugin)) {
+		    foreach ($plugin as $path) {
+                if (in_array( $path, self::$active_plugins ) || array_key_exists( $path, self::$active_plugins )) {
+                    return true;
+                }
+            }
+            return false;
+		} else {
+		    return in_array( $plugin, self::$active_plugins ) || array_key_exists( $plugin, self::$active_plugins );
+		}
+
 	}
 
 	public static function woocommerce_active_check() {

--- a/class-aftership-settings.php
+++ b/class-aftership-settings.php
@@ -40,7 +40,7 @@ class AfterShip_Settings
         $this->plugins[] = array(
             'value' => 'wc-shipment-tracking',
             'label' => 'WooCommerce Shipment Tracking',
-            'path' => 'woocommerce-shipment-tracking/shipment-tracking.php'
+            'path' => array('woocommerce-shipment-tracking/shipment-tracking.php', 'woocommerce-shipment-tracking/woocommerce-shipment-tracking.php')
         );
 
         add_action('admin_menu', array($this, 'add_plugin_page'));

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.aftership.com/
 Tags: shipping, tracking, ups, usps, fedex, dhl, tnt, dpd, post, shipment, woocommerce, tracking number, aftership, package tracking, fulfilment, tracking link, carrier, courier, woo commerce, woocommerce shipment tracking, shipping details plugin, widget, shipstation, track, package
 Requires at least: 2.9
 Tested up to: 4.2.2
-Stable tag: 1.6.4
+Stable tag: 1.6.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -96,6 +96,9 @@ You'll find the FAQ on [AfterShip.com](https://aftership.uservoice.com/knowledge
 7. Automatically send out delivery notifications
 
 == Changelog ==
+
+= 1.6.5 =
+* Support new version of Woocommerce Shipment Tracking plugin
 
 = 1.6.4 =
 * Add new couriers


### PR DESCRIPTION
https://aftership.atlassian.net/browse/AS-3971
They renamed the file from `shipment-tracking.php` to `woocommerce-shipment-tracking.php`.
Have tested:
* `woocommerce-shipment-tracking.php` and `shipment-tracking.php` shows up in dropdown
* `shipment-tracking-blablabla.php` does not show up in dropdown