### PR TITLE
[AS-5087] Fix incompatibility with sendcloud plugin

### DIFF
--- a/class-aftership-api.php
+++ b/class-aftership-api.php
@@ -157,9 +157,6 @@ class AfterShip_API
 
 		// self api
 		include_once('api/class-aftership-api-orders.php');
-
-		// allow plugins to load other response handlers or resource classes
-		do_action('woocommerce_api_loaded');
 	}
 
 	/**


### PR DESCRIPTION
https://aftership.atlassian.net/browse/AS-5087

We should't trigger woocommerce_api_loaded, since this can cause other plugins'
callbacks to run. (And we haven't actually loaded woocommerce api, so they
will crash)