### PR TITLE
Issue46

### DIFF
--- a/aftership.php
+++ b/aftership.php
@@ -445,6 +445,12 @@ if (is_woocommerce_active()) {
                     $track_message_1 = 'Your order was shipped via ';
                     $track_message_2 = 'Tracking number is ';
                 }
+                
+                if (array_key_exists('override_track_message', $options)) {
+                    $override_track_message = $options['override_track_message']; 
+                } else {
+                  $override_track_message = '';
+                }
 
                 $required_fields_values = array();
                 $provider_required_fields = explode(",", $values['aftership_tracking_required_fields']);
@@ -464,9 +470,14 @@ if (is_woocommerce_active()) {
                     $required_fields_msg = '';
                 }
 
-
-                echo $track_message_1 . $values['aftership_tracking_provider_name'] . '<br/>' . $track_message_2 . $values['aftership_tracking_number'] . $required_fields_msg;
-
+                if(strlen($override_track_message)){
+                  $override_track_message = str_replace('%tracking_number%', $values['aftership_tracking_number'], $override_track_message);
+                  $override_track_message = str_replace('%tracking_provider_name%', $values['aftership_tracking_provider_name'], $override_track_message);
+                  echo $override_track_message . $required_fields_msg;
+                } else {
+                  echo $track_message_1 . $values['aftership_tracking_provider_name'] . '<br/>' . $track_message_2 . $values['aftership_tracking_number'] . $required_fields_msg;
+                }
+                
                 if (!$for_email && $this->use_track_button) {
                     $this->display_track_button($values['aftership_tracking_provider'], $values['aftership_tracking_number'], $required_fields_values);
                 }

--- a/assets/js/setting.js
+++ b/assets/js/setting.js
@@ -21,11 +21,18 @@ jQuery(function () {
     }
 
     function set_track_message_demo(){
-        jQuery('#track_message_demo_1').html(
-            jQuery('#track_message_1').val() + 'UPS' +
-                '<br/>'+
-            jQuery('#track_message_2').val() + '1Z0X118A0324011613'
-        );
+        if (jQuery('#override_track_message').val()) {
+            let demo_html = jQuery('#override_track_message').val();
+            demo_html = demo_html.replace(/%tracking_provider_name%/gi, 'UPS');
+            demo_html = demo_html.replace(/%tracking_number%/gi, '1Z0X118A0324011613');
+            jQuery('#track_message_demo_1').html(demo_html);
+        } else {
+            jQuery('#track_message_demo_1').html(
+                jQuery('#track_message_1').val() + 'UPS' +
+                    '<br/>' +
+                jQuery('#track_message_2').val() + '1Z0X118A0324011613'
+            );
+        }     
     }
 
     jQuery('#couriers_select').change(function () {

--- a/class-aftership-settings.php
+++ b/class-aftership-settings.php
@@ -298,7 +298,7 @@ class AfterShip_Settings
         );
         printf('<br/>');
         printf('<br/>');
-        printf('<b>Override track messages with the following (use %tracking_number% and %shipping_method% variables):</b>');
+        printf('<b>Override track messages with the following (use %tracking_number% and %tracking_provider_name% variables):</b>');
         printf(
           '<input type="text" id="override_track_message" name="aftership_option_name[override_track_message]" value="%s" style="width:100%%">',
           isset($this->options['override_track_message']) ? htmlspecialchars($this->options['override_track_message']) : ''

--- a/class-aftership-settings.php
+++ b/class-aftership-settings.php
@@ -298,11 +298,13 @@ class AfterShip_Settings
         );
         printf('<br/>');
         printf('<br/>');
-        printf('<b>Override track messages with the following (use %tracking_number% and %tracking_provider_name% variables):</b>');
+        echo '<b>Override track messages with the following (use <em>%tracking_number%</em> and <em>%tracking_provider_name%</em> placeholder variables):</b>';
         printf(
           '<input type="text" id="override_track_message" name="aftership_option_name[override_track_message]" value="%s" style="width:100%%">',
           isset($this->options['override_track_message']) ? htmlspecialchars($this->options['override_track_message']) : ''
         );
+        printf('<br/>');
+        printf('<br/>');
         printf('<b>Demo:</b>');
         printf(
             '<div id="track_message_demo_1" style="width:100%%"></div>'

--- a/class-aftership-settings.php
+++ b/class-aftership-settings.php
@@ -200,6 +200,29 @@ class AfterShip_Settings
             $new_input['track_message_2'] = sanitize_text_field($input['track_message_2']) . $postfix;
         }
 
+        if (isset($input['override_track_message'])) {
+            $postfix = '';
+            if (substr($input['override_track_message'], -1) == ' ') {
+                $postfix = ' ';
+            }
+            $allowed_html = array (
+              'a' => array (
+                'href' => array(),
+                'class' => array(),
+              ),
+              'br' => array(),
+              'em' => array(),
+              'strong' => array(),
+              'p' => array(),
+              'h1' => array(),
+              'h2' => array(),
+              'h3' => array(),
+              'h4' => array(),
+              'h5' => array(),
+            );
+            $new_input['override_track_message'] = wp_kses($input['override_track_message'],$allowed_html);
+        }
+
         if (isset($input['use_track_button'])) {
             $new_input['use_track_button'] = true;
         }
@@ -275,6 +298,11 @@ class AfterShip_Settings
         );
         printf('<br/>');
         printf('<br/>');
+        printf('<b>Override track messages with the following (use %tracking_number% and %shipping_method% variables):</b>');
+        printf(
+          '<input type="text" id="override_track_message" name="aftership_option_name[override_track_message]" value="%s" style="width:100%%">',
+          isset($this->options['override_track_message']) ? htmlspecialchars($this->options['override_track_message']) : ''
+        );
         printf('<b>Demo:</b>');
         printf(
             '<div id="track_message_demo_1" style="width:100%%"></div>'


### PR DESCRIPTION
This is my attempt to resolve issue #46. 

Rather than create separate variables for adding tags before and after the track messages and track variables, I decided to make a single new input field that allows the entire block to be overridden with custom html and placeholders for the variables. 

![image](https://user-images.githubusercontent.com/8247632/69566199-d0629a00-0f73-11ea-8cba-7b2d03ec1588.png)

`Your order was shipped via %tracking_provider_name%.<br>Your tracking number is  <a href="https://atptrack.aftership.com/%tracking_number%">%tracking_number%</a>. <br><br>`

![image](https://user-images.githubusercontent.com/8247632/69566244-e53f2d80-0f73-11ea-9da7-b0abb5fb9a83.png)

