### PR TITLE
A more visible tracking information text

### DIFF
--- a/aftership.php
+++ b/aftership.php
@@ -441,9 +441,11 @@ if (is_woocommerce_active()) {
                 if (array_key_exists('track_message_1', $options) && array_key_exists('track_message_2', $options)) {
                     $track_message_1 = $options['track_message_1'];
                     $track_message_2 = $options['track_message_2'];
+                    $custom_domain = $options['custom_domain'];
                 } else {
-                    $track_message_1 = 'Your order was shipped via ';
-                    $track_message_2 = 'Tracking number is ';
+                    $track_message_1 = 'Carrier';
+                    $track_message_2 = 'Tracking Number';
+                    $custom_domain = 'https://track.aftership.com/';
                 }
 
                 $required_fields_values = array();
@@ -465,7 +467,16 @@ if (is_woocommerce_active()) {
                 }
 
 
-                echo $track_message_1 . $values['aftership_tracking_provider_name'] . '<br/>' . $track_message_2 . $values['aftership_tracking_number'] . $required_fields_msg;
+                echo '<H2 style="FONT-SIZE: 18px; FONT-FAMILY: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; FONT-WEIGHT: bold; COLOR: #557da1; TEXT-ALIGN: left; MARGIN: 0px 0px 18px; DISPLAY: block; LINE-HEIGHT: 130%">Tracking Information</H2>';
+                echo '<section><table class="shop_table shop_table_responsive yqtrack_tracking" style="width: 100%; border-collapse: collapse;">';
+                echo '<thead><tr><th style="text-align: center; font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px;">';
+                echo $track_message_1.'</th><th style="text-align: center; font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px;">';
+                echo $track_message_2.'</th><th style="text-align: center; font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px;">';
+                echo '</th></tr></thead><tbody><tr><td style="font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px; text-align: center;">';
+                echo $values['aftership_tracking_provider_name'].'</td><td style="font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px; text-align: center;">';
+                echo $values['aftership_tracking_number'].'</td><td style="font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px; text-align: center;">';
+                echo '<a href="'.$custom_domain.'/'.$values['aftership_tracking_number'].'" target="_blank" class="button" style="color: #557da1; font-weight: normal; text-decoration: underline;">Track on Aftership</a><br>or<br>';
+                echo '<a href="https://t.17track.net#nums='.$values['aftership_tracking_number'].'&amp;fc=09061" target="_blank" class="button" style="color: #557da1; font-weight: normal; text-decoration: underline;">Track on 17Track</a></td></tr></tbody></table></section><br>';
 
                 if (!$for_email && $this->use_track_button) {
                     $this->display_track_button($values['aftership_tracking_provider'], $values['aftership_tracking_number'], $required_fields_values);

--- a/assets/js/setting.js
+++ b/assets/js/setting.js
@@ -22,9 +22,16 @@ jQuery(function () {
 
     function set_track_message_demo(){
         jQuery('#track_message_demo_1').html(
-            jQuery('#track_message_1').val() + 'UPS' +
-                '<br/>'+
-            jQuery('#track_message_2').val() + '1Z0X118A0324011613'
+            '<H2 style="FONT-SIZE: 18px; FONT-FAMILY: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; FONT-WEIGHT: bold; COLOR: #557da1; TEXT-ALIGN: left; MARGIN: 0px 0px 18px; DISPLAY: block; LINE-HEIGHT: 130%">Tracking Information</H2>' +
+            '<section><table class="shop_table shop_table_responsive yqtrack_tracking" style="width: 100%; border-collapse: collapse;">' +
+            '<thead><tr><th style="text-align: center; font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px;">' +
+            jQuery('#track_message_1').val() + '</th><th style="text-align: center; font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px;">' +
+            jQuery('#track_message_2').val() + '</th><th style="text-align: center; font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px;">' +
+            '</th></tr></thead><tbody><tr><td style="font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px; text-align: center;">' +
+            'UPS' + '</td><td style="font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px; text-align: center;">' +
+            '123123123123' + '</td><td style="font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px; text-align: center;">' +
+            '<a href="'+jQuery('#custom_domain').val()+'/'+'123123123123'+'" target="_blank" class="button" style="color: #557da1; font-weight: normal; text-decoration: underline;">Track on Aftership</a><br>or<br>' +
+            '<a href="https://t.17track.net#nums='+'123123123123'+'&amp;fc=09061" target="_blank" class="button" style="color: #557da1; font-weight: normal; text-decoration: underline;">Track on 17Track</a></td></tr></tbody></table></section><br>'+
         );
     }
 

--- a/assets/js/setting.js
+++ b/assets/js/setting.js
@@ -31,7 +31,7 @@ jQuery(function () {
             'UPS' + '</td><td style="font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px; text-align: center;">' +
             '123123123123' + '</td><td style="font-family: \'Helvetica Neue\', Helvetica, Roboto, Arial, sans-serif; font-size: px; color: #737373; border: 1px solid #e4e4e4; padding: 12px; text-align: center;">' +
             '<a href="'+jQuery('#custom_domain').val()+'/'+'123123123123'+'" target="_blank" class="button" style="color: #557da1; font-weight: normal; text-decoration: underline;">Track on Aftership</a><br>or<br>' +
-            '<a href="https://t.17track.net#nums='+'123123123123'+'&amp;fc=09061" target="_blank" class="button" style="color: #557da1; font-weight: normal; text-decoration: underline;">Track on 17Track</a></td></tr></tbody></table></section><br>'+
+            '<a href="https://t.17track.net#nums='+'123123123123'+'&amp;fc=09061" target="_blank" class="button" style="color: #557da1; font-weight: normal; text-decoration: underline;">Track on 17Track</a></td></tr></tbody></table></section><br>'
         );
     }
 

--- a/class-aftership-settings.php
+++ b/class-aftership-settings.php
@@ -266,12 +266,12 @@ class AfterShip_Settings
     {
         printf(
             '<input type="text" id="track_message_1" name="aftership_option_name[track_message_1]" value="%s" style="width:100%%">',
-            isset($this->options['track_message_1']) ? $this->options['track_message_1'] : 'Your order was shipped via '
+            isset($this->options['track_message_1']) ? $this->options['track_message_1'] : 'Carrier'
         );
         printf('<br/>');
         printf(
             '<input type="text" id="track_message_2" name="aftership_option_name[track_message_2]" value="%s" style="width:100%%">',
-            isset($this->options['track_message_2']) ? $this->options['track_message_2'] : 'Tracking number is '
+            isset($this->options['track_message_2']) ? $this->options['track_message_2'] : 'Tracking Number'
         );
         printf('<br/>');
         printf('<br/>');


### PR DESCRIPTION
The current tracking information text is barely noticeable by customers at best. Customers tend to miss it in the emails and keep contacting the store for more info about their tracking information for their orders. 

I changed the text to a more visible table. Also, the tracking info now links to the yoursite.aftership.com page to display the actual tracking history.
[Clipboard01](https://user-images.githubusercontent.com/15445491/79735312-bfd70580-8300-11ea-9225-e38b3c71541c.jpg)

And, added a secondary tracking option in case aftership does not show info about the tracking number or the client wishes to look further into his tracking information. Since 17track shows tracking information from both the ORIGIN and DESTINATION, it sometimes displays important information for the client (i would suggest aftership to do the same!).