### PR TITLE
Add variant detail for protection ajax cart

### DIFF
--- a/aftership-woocommerce-tracking.php
+++ b/aftership-woocommerce-tracking.php
@@ -3,7 +3,7 @@
  * Plugin Name: AfterShip Tracking - All-In-One WooCommerce Order Tracking (Free plan available)
  * Plugin URI: http://aftership.com/
  * Description: Track orders in one place. shipment tracking, automated notifications, order lookup, branded tracking page, delivery day prediction
- * Version: 1.17.2
+ * Version: 1.17.3
  * Author: AfterShip
  * Author URI: http://aftership.com
  *
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once( 'woo-includes/woo-functions.php' );
 
-define( 'AFTERSHIP_VERSION', '1.17.2' );
+define( 'AFTERSHIP_VERSION', '1.17.3' );
 define( 'AFTERSHIP_PATH', dirname( __FILE__ ) );
 define( 'AFTERSHIP_ASSETS_URL', plugins_url() . '/' . basename( AFTERSHIP_PATH ) );
 define( 'AFTERSHIP_SCRIPT_TAGS', 'aftership_script_tags' );

--- a/includes/class-aftership-protection.php
+++ b/includes/class-aftership-protection.php
@@ -87,6 +87,10 @@ class AfterShip_Protection {
 		$wc_cart = WC()->cart;
 		$cart = $wc_cart->get_cart();
 		foreach ( $cart as $cart_item_key => $cart_item ) {
+			if (isset($cart_item['variation_id']) && isset($cart_item['variation'])) {
+				$variation    = new WC_Product_Variation( $cart_item['variation_id'] );
+				$cart[$cart_item_key]['variation'] = array_merge($cart_item['variation'], $variation->get_data());
+			}
 			$product = wc_get_product( $cart_item['product_id'] );
 			$cart[$cart_item_key]['product'] = $product->get_data();
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.aftership.com/
 Tags: woocommerce shipping,woocommerce tracking,shipment tracking,order tracking, woocommerce,track order,dhl,ups,usps,fedex,shipping,tracking,order
 Requires at least: 2.9
 Tested up to: 6.3
-Stable tag: 1.17.2
+Stable tag: 1.17.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
![image](https://github.com/AfterShip/aftership-apps-woocommerce/assets/5866775/ef686b29-946c-41ce-ac64-f27cd7fd8618)

增加返回了 variant 产品的详细信息，避免出现 product 是 virtual 但是 variant 不是 virtual 这种 case 