### PR TITLE
[CI]fix error - get_order_number

### DIFF
--- a/aftership-woocommerce-tracking.php
+++ b/aftership-woocommerce-tracking.php
@@ -3,7 +3,7 @@
  * Plugin Name: AfterShip Tracking - All-In-One WooCommerce Order Tracking (Free plan available)
  * Plugin URI: http://aftership.com/
  * Description: Track orders in one place. shipment tracking, automated notifications, order lookup, branded tracking page, delivery day prediction
- * Version: 1.18.0
+ * Version: 1.17.10
  * Author: AfterShip
  * Author URI: http://aftership.com
  *
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once( 'woo-includes/woo-functions.php' );
 
-define( 'AFTERSHIP_VERSION', '1.18.0' );
+define( 'AFTERSHIP_VERSION', '1.17.10' );
 define( 'AFTERSHIP_PATH', dirname( __FILE__ ) );
 define( 'AFTERSHIP_ASSETS_URL', plugins_url() . '/' . basename( AFTERSHIP_PATH ) );
 define( 'AFTERSHIP_SCRIPT_TAGS', 'aftership_script_tags' );

--- a/aftership-woocommerce-tracking.php
+++ b/aftership-woocommerce-tracking.php
@@ -3,7 +3,7 @@
  * Plugin Name: AfterShip Tracking - All-In-One WooCommerce Order Tracking (Free plan available)
  * Plugin URI: http://aftership.com/
  * Description: Track orders in one place. shipment tracking, automated notifications, order lookup, branded tracking page, delivery day prediction
- * Version: 1.17.8
+ * Version: 1.18.0
  * Author: AfterShip
  * Author URI: http://aftership.com
  *
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once( 'woo-includes/woo-functions.php' );
 
-define( 'AFTERSHIP_VERSION', '1.17.8' );
+define( 'AFTERSHIP_VERSION', '1.18.0' );
 define( 'AFTERSHIP_PATH', dirname( __FILE__ ) );
 define( 'AFTERSHIP_ASSETS_URL', plugins_url() . '/' . basename( AFTERSHIP_PATH ) );
 define( 'AFTERSHIP_SCRIPT_TAGS', 'aftership_script_tags' );

--- a/includes/class-aftership-import-csv.php
+++ b/includes/class-aftership-import-csv.php
@@ -112,8 +112,12 @@ class AfterShip_Import_Csv {
 		// The user has enabled Import Tracking.
 		// Only need detect once: the user's store order number has used default id or has customized order number
 		if ( empty( $this->options['import_tracking'] ) ) {
-			// Query the user's latest order to determine: 1. whether the user has used a custom number 2. the custom fields used
-			$this->check_use_custom_order_number();
+			try {
+				// Query the user's latest order to determine: 1. whether the user has used a custom number 2. the custom fields used
+				$this->check_use_custom_order_number();
+			} catch (Throwable $ex) {
+				return;
+			}
 		}
 	}
 
@@ -124,6 +128,7 @@ class AfterShip_Import_Csv {
 		// Query the user's latest order
 		$latest_orders = wc_get_orders(
 			array(
+				'type' => 'shop_order',
 				'limit'   => 1,
 				'orderby' => 'date',
 				'order'   => 'DESC',

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.aftership.com/
 Tags: woocommerce shipping,woocommerce tracking,shipment tracking,order tracking, woocommerce,track order,dhl,ups,usps,fedex,shipping,tracking,order
 Requires at least: 2.9
 Tested up to: 6.3
-Stable tag: 1.17.8
+Stable tag: 1.18.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -141,7 +141,7 @@ Tailor a dynamic branded tracking page. Upload promotional banner, logo, and fav
 
 == Changelog ==
 
-= 1.17.8 =
+= 1.18.0 =
 * Enhancement: support order number column (csv template) for Import Tracking
 
 = 1.17.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.aftership.com/
 Tags: woocommerce shipping,woocommerce tracking,shipment tracking,order tracking, woocommerce,track order,dhl,ups,usps,fedex,shipping,tracking,order
 Requires at least: 2.9
 Tested up to: 6.3
-Stable tag: 1.18.0
+Stable tag: 1.17.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -141,7 +141,7 @@ Tailor a dynamic branded tracking page. Upload promotional banner, logo, and fav
 
 == Changelog ==
 
-= 1.18.0 =
+= 1.17.10 =
 * Enhancement: support order number column (csv template) for Import Tracking
 
 = 1.17.0 =


### PR DESCRIPTION
Error Details
=============
An error of type E_ERROR was caused in line 140 of the file /home/wwwroot/wordpress14/wp-content/plugins/aftership-woocommerce-tracking/includes/class-aftership-import-csv.php. Error message: Uncaught Error: Call to undefined method Automattic\WooCommerce\Admin\Overrides\OrderRefund::get_order_number() in /home/wwwroot/wordpress14/wp-content/plugins/aftership-woocommerce-tracking/includes/class-aftership-import-csv.php:140
Stack trace:
#0 /home/wwwroot/wordpress14/wp-content/plugins/aftership-woocommerce-tracking/includes/class-aftership-import-csv.php(116): AfterShip_Import_Csv->check_use_custom_order_number()
#1 /home/wwwroot/wordpress14/wp-includes/class-wp-hook.php(324): AfterShip_Import_Csv->add_menu()
#2 /home/wwwroot/wordpress14/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters()
#3 /home/wwwroot/wordpress14/wp-includes/plugin.php(517): WP_Hook->do_action()
#4 /home/wwwroot/wordpress14/wp-admin/includes/menu.php(161): do_action()
#5 /home/wwwroot/wordpress14/wp-admin/menu.php(417): require_once('/home/wwwroot/w...')
#6 /home/wwwroot/wordpress14/wp-admin/admin.php(158): require('/home/wwwroot/w...')
#7 {main}
  thrown